### PR TITLE
Fixed coordinates bug in interpolate()

### DIFF
--- a/envmap/environmentmap.py
+++ b/envmap/environmentmap.py
@@ -161,7 +161,7 @@ class EnvironmentMap:
 
     def interpolate(self, u, v, valid, method='linear'):
         """"Interpolate to get the desired pixel values."""
-        target = np.vstack((v.flatten()*self.data.shape[0], u.flatten()*self.data.shape[1]))
+        target = np.vstack(((v.flatten()+.5)*self.data.shape[0], (u.flatten()+.5)*self.data.shape[1]))
 
         # Repeat the first and last rows/columns for interpolation purposes
         h, w, d = self.data.shape


### PR DESCRIPTION
Fixed coordinates bug in function interpolate. The target coordinates should be positive.