### PR TITLE
pySolar update

### DIFF
--- a/hdrtools/sunutils.py
+++ b/hdrtools/sunutils.py
@@ -72,11 +72,9 @@ def sunPosFromCoord(latitude, longitude, time_, elevation=0):
     Find azimuth annd elevation of the sun using the pysolar library.
     Takes latitude(deg), longitude(deg) and a datetime object.
     Return tuple conaining (elevation, azimuth)
-
-    TODO verify if timezone influences the results.
     """
-    # import datetime
-    # time_ = datetime.datetime(2014, 10, 11, 9, 55, 28)
+    
+    # Find azimuth annd elevation from pysolar library.
     azim = solar.get_azimuth(latitude, longitude, time_, elevation)
     alti = solar.get_altitude(latitude, longitude, time_, elevation)
 

--- a/setup.py
+++ b/setup.py
@@ -18,5 +18,5 @@ setup(
     version=skylibs_module['__version__'],
     packages=['ezexr', 'envmap', 'hdrio', 'hdrtools', 'hdrtools/tonemapping', 'skydb', 'tools3d', 'skylibs'],
     include_package_data=True,
-    install_requires=['imageio>=1.6', 'tqdm', 'numpy', 'scipy', 'scikit-image>=0.19'],
+    install_requires=['imageio>=1.6', 'tqdm', 'numpy', 'scipy', 'scikit-image>=0.19', 'pysolar'],
 )

--- a/skydb/__init__.py
+++ b/skydb/__init__.py
@@ -2,7 +2,6 @@ import os
 from os import listdir
 from os.path import abspath, isdir, join
 import fnmatch
-import pytz
 import datetime
 
 import numpy as np
@@ -151,17 +150,14 @@ class SkyProbe:
             latitude, longitude = 46.778969, -71.274914
             elevation = 125
 
-            if self.datetime < datetime.datetime(2013, 12, 25, 10, 10, 10, tzinfo=pytz.timezone('US/Eastern')):
+            tz = datetime.timezone(datetime.timedelta(seconds=-17760))
+            if self.datetime < datetime.datetime(2013, 12, 25, 10, 10, 10, tzinfo=tz):
                 # Assume Carnegie Mellon University, Pittsburgh, PA
                 latitude, longitude = 40.442794, -79.944115
                 elevation = 300
 
             d = self.datetime
             if self.datetime.tzinfo is None:
-                # Skydb does not store timezone information
-                # Both localities are in the same timezone (UTC-4)
-                # and can be corrected by adding 4 hours to UTC timestamp through
-                # d += datetime.timedelta(hours=+4) OR by adding timezone information as below
-                d = pytz.timezone('US/Eastern').localize(d, is_dst=False)
+                d += datetime.timedelta(hours=+4)
 
             return sunutils.sunPosFromCoord(latitude, longitude, d, elevation=elevation)

--- a/skydb/__init__.py
+++ b/skydb/__init__.py
@@ -2,6 +2,7 @@ import os
 from os import listdir
 from os.path import abspath, isdir, join
 import fnmatch
+import pytz
 import datetime
 
 import numpy as np
@@ -144,20 +145,23 @@ class SkyProbe:
         if method == "intensity":
             self.init_properties()
             return sunutils.sunPosFromEnvmap(self._envmap)
+
         elif method == "coords":
-            latitude = 46.778969
-            longitude = -71.274914
+            # Assume Laval University, Quebec, Canada
+            latitude, longitude = 46.778969, -71.274914
             elevation = 125
 
-            if self.datetime < datetime.datetime(2013, 12, 25, 10, 10, 10):
+            if self.datetime < datetime.datetime(2013, 12, 25, 10, 10, 10, tzinfo=pytz.timezone('US/Eastern')):
+                # Assume Carnegie Mellon University, Pittsburgh, PA
                 latitude, longitude = 40.442794, -79.944115
                 elevation = 300
 
             d = self.datetime
             if self.datetime.tzinfo is None:
-                #TODO get timezone from latitude and longitude
-                # d = pytz.timezone('US/Eastern').localize(self.datetime, is_dst=False)
-                d += datetime.timedelta(hours=+4)
-
+                # Skydb does not store timezone information
+                # Both localities are in the same timezone (UTC-4)
+                # and can be corrected by adding 4 hours to UTC timestamp through
+                # d += datetime.timedelta(hours=+4) OR by adding timezone information as below
+                d = pytz.timezone('US/Eastern').localize(d, is_dst=False)
 
             return sunutils.sunPosFromCoord(latitude, longitude, d, elevation=elevation)


### PR DESCRIPTION
Resolves  [TODO verify if timezone influences the results](https://github.com/soravux/skylibs/blob/aea5a288e15870534f310871e2cfa1c3496b3080/hdrtools/sunutils.py#L76).

pySolar accepts UTC timestamps and any other correctly localized timestamp. 

```
tz_qc = pytz.timezone('US/Eastern')
time = dt.datetime(year, month, day, hour, minute, second, tzinfo=tz_qc)
```
![image](https://user-images.githubusercontent.com/7108263/192151288-ecbe09ae-61dd-4cd0-9b0a-ab5784343bfd.png)

```
tz_utc = pytz.timezone('UTC')
time = dt.datetime(year, month, day, hour, minute, second, tzinfo=tz_utc)
time += dt.timedelta(hours=+4)
```
![image](https://user-images.githubusercontent.com/7108263/192151383-c7c36711-bc4a-4f7e-8e04-c83573fdbd24.png)

Removed [#TODO get timezone from latitude and longitude ](https://github.com/soravux/skylibs/blob/aea5a288e15870534f310871e2cfa1c3496b3080/skydb/__init__.py#L158) as this is unadvisible and irrelevant for:
-  Skydb only has two localities.
- Timezones move and require updating. Many python libraries which perform this functionality are deprecated. Ex: [tzqwhere](https://github.com/mattbornski/tzwhere) and its fork [ptzwhere](https://github.com/pegler/pytzwhere). 

Regardless, if desired, this functionality may be implementable through [timezonefinder](https://timezonefinder.readthedocs.io/en/latest/) but I don't think this code should not be part of the skydb module (maybe [sunutils.py](https://github.com/soravux/skylibs/blob/aea5a288e15870534f310871e2cfa1c3496b3080/hdrtools/sunutils.py)?). 
