### PR TITLE
Fixed error in test_imageCoordinates()

### DIFF
--- a/envmap/test_environmentmap.py
+++ b/envmap/test_environmentmap.py
@@ -5,7 +5,7 @@ from . import EnvironmentMap
 
 def test_imageCoordinates():
     for s in range(4, 9, 4):
-        e = EnvironmentMap(np.zeros((s,s)), 'Angular')
+        e = EnvironmentMap(np.zeros((s,s,1)), 'Angular')
         u, v = e.imageCoordinates()
         # All rows/columns are the same
         assert np.all(np.diff(u, axis=0) == 0)


### PR DESCRIPTION
Missing number of color channels in test case

```python
=================================================================================== FAILURES ===================================================================================
____________________________________________________________________________ test_imageCoordinates _____________________________________________________________________________

    def test_imageCoordinates():
        for s in range(4, 9, 4):
>           e = EnvironmentMap(np.zeros((s,s)), 'Angular')

envmap/test_environmentmap.py:8: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
envmap/environmentmap.py:96: in __init__
    self.validate()
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <envmap.environmentmap.EnvironmentMap object at 0x7f0be80ff9d0>

    def validate(self):
        # Ensure the envmap is valid
        if self.format_ in ['sphere', 'angular', 'skysphere', 'skyangular']:
            assert self.data.shape[0] == self.data.shape[1], (
                "Sphere/Angular formats must have the same width/height")
        elif self.format_ == 'latlong':
            assert 2*self.data.shape[0] == self.data.shape[1], (
                "LatLong format width should be twice the height")
        elif self.format_ == 'skylatlong':
            assert 4*self.data.shape[0] == self.data.shape[1], (
                "SkyLatLong format width should be four times the height")
    
>       assert self.data.ndim == 3, "Expected 3-dim array. For grayscale, use [h,w,1]."
E       AssertionError: Expected 3-dim array. For grayscale, use [h,w,1].

envmap/environmentmap.py:110: AssertionError
```