### PR TITLE
Interpolation parameters

### DIFF
--- a/envmap/environmentmap.py
+++ b/envmap/environmentmap.py
@@ -391,7 +391,7 @@ class EnvironmentMap:
                 old_mean = self.data.mean()
 
         # downsampling
-        if targetSize[0] < self.data.shape[0] and order !=0:
+        if targetSize[0] < self.data.shape[0] and order != 0:
 
 
             # check if integer

--- a/envmap/rotations.py
+++ b/envmap/rotations.py
@@ -26,3 +26,10 @@ def rotz(theta):
     return np.array([[np.cos(theta), -np.sin(theta), 0],
                      [np.sin(theta), np.cos(theta), 0],
                      [0, 0, 1]], dtype='float64')
+
+
+def rot(theta=(0,0,0)):
+    """
+    Produces a counter-clockwise 3D rotation matrix around axis X, Y and Z with angles `theta` in radians.
+    """
+    return np.dot(rotz(theta[2]), np.dot(roty(theta[1]), rotx(theta[0])))

--- a/test/test_envmap.py
+++ b/test/test_envmap.py
@@ -197,7 +197,7 @@ def test_worldCoordinates_ndarray(format_, normal):
     u, v = e.world2image(*normal)
 
 
-@pytest.mark.parametrize("format_1, format_2",  product(SUPPORTED_FORMATS,SUPPORTED_FORMATS))
+@pytest.mark.parametrize("format_1, format_2", product(SUPPORTED_FORMATS, SUPPORTED_FORMATS))
 def test_interpolation_convertTo_discrete_values(format_1, format_2):
     # test interpolation order 0 (nearest neighbor)
 
@@ -209,19 +209,19 @@ def test_interpolation_convertTo_discrete_values(format_1, format_2):
     # convertTo()
     e_2 = e_1.convertTo(format_2, order=0)
     # e_2 contains nan values... ¯\_(ツ)_/¯
-    unique_2 = [ x for x in np.unique(e_2.data) if not np.isnan(x) ]
+    unique_2 = [x for x in np.unique(e_2.data) if not np.isnan(x)]
 
     assert len(unique_2) > 0, f"Format {format_1}->{format_2}: unique_2 is empty"
     for x in unique_2:
         assert x in unique_1, f"Format {format_1}->{format_2}: {x} was not in unique_1"
 
 
-@pytest.mark.parametrize("format_1",  (SUPPORTED_FORMATS))
-def test_interpolation_rotate_discrete_values(format_1):
+@pytest.mark.parametrize("format_", SUPPORTED_FORMATS)
+def test_interpolation_rotate_discrete_values(format_):
     # rotate() should not change the unique values in the data
     for i in range(0,360,10):
-        e_1 = EnvironmentMap(128, format_1)
-        e_1.data = np.random.randint(0,512, size=e_1.data.shape)
+        e_1 = EnvironmentMap(128, format_)
+        e_1.data = np.random.randint(0, 512, size=e_1.data.shape)
         unique_1 = np.unique(e_1.data)
 
         # Rotate
@@ -230,22 +230,22 @@ def test_interpolation_rotate_discrete_values(format_1):
         e_2 = e_1.rotate(dcm, order=0)
 
         unique_2 = np.unique(e_2.data) 
-        assert len(unique_2) > 0, f"Format {format_1}: unique_2 is empty"
+        assert len(unique_2) > 0, f"Format {format_}: unique_2 is empty"
         for x in unique_2:
-            assert x in unique_1, f"Format {format_1}: {x} was not in {unique_1}"
+            assert x in unique_1, f"Format {format_}: {x} was not in {unique_1}"
 
 
-@pytest.mark.parametrize("format_1",  (SUPPORTED_FORMATS))
-def test_interpolation_resize_discrete_values(format_1):
+@pytest.mark.parametrize("format_", SUPPORTED_FORMATS)
+def test_interpolation_resize_discrete_values(format_):
     # scale() should not change the unique values in the data while upscaling
     for s in [32,64,100,200,256,512]:
-        e_1 = EnvironmentMap(128, format_1)
-        e_1.data = np.random.randint(0,128, size=e_1.data.shape)
+        e_1 = EnvironmentMap(128, format_)
+        e_1.data = np.random.randint(0, 128, size=e_1.data.shape)
         unique_1 = [ x for x in np.unique(e_1.data) if not np.isnan(x) ]
 
         e_2 = e_1.resize(s, order=0)
         unique_2 = [ x for x in np.unique(e_2.data) if not np.isnan(x) ]
 
-        assert len(unique_2) > 0, f"Format {format_1}: unique_2 is empty"
+        assert len(unique_2) > 0, f"Format {format_}: unique_2 is empty"
         for x in unique_2:
-            assert x in unique_1 , f"Format {format_1}: {x} was not in {unique_1}"
+            assert x in unique_1 , f"Format {format_}: {x} was not in {unique_1}"

--- a/test/test_envmap.py
+++ b/test/test_envmap.py
@@ -3,7 +3,7 @@ from itertools import product
 import pytest
 from skimage.transform import resize
 from scipy.ndimage import binary_erosion
-from envmap import EnvironmentMap, rotation_matrix
+from envmap import EnvironmentMap, rotation_matrix, rotations
 from envmap.environmentmap import SUPPORTED_FORMATS
 
 
@@ -195,3 +195,57 @@ def test_worldCoordinates_ndarray(format_, normal):
 
     normal = np.asarray(normal)
     u, v = e.world2image(*normal)
+
+
+@pytest.mark.parametrize("format_1, format_2",  product(SUPPORTED_FORMATS,SUPPORTED_FORMATS))
+def test_interpolation_convertTo_discrete_values(format_1, format_2):
+    # test interpolation order 0 (nearest neighbor)
+
+    # converTo() should not change the unique values in the data
+    e_1 = EnvironmentMap(128, format_1)
+    e_1.data = np.random.randint(0,512, size=e_1.data.shape)
+    unique_1 = np.unique(e_1.data)
+        
+    # convertTo()
+    e_2 = e_1.convertTo(format_2, order=0)
+    # e_2 contains nan values... ¯\_(ツ)_/¯
+    unique_2 = [ x for x in np.unique(e_2.data) if not np.isnan(x) ]
+
+    assert len(unique_2) > 0, f"Format {format_1}->{format_2}: unique_2 is empty"
+    for x in unique_2:
+        assert x in unique_1, f"Format {format_1}->{format_2}: {x} was not in unique_1"
+
+
+@pytest.mark.parametrize("format_1",  (SUPPORTED_FORMATS))
+def test_interpolation_rotate_discrete_values(format_1):
+    # rotate() should not change the unique values in the data
+    for i in range(0,360,10):
+        e_1 = EnvironmentMap(128, format_1)
+        e_1.data = np.random.randint(0,512, size=e_1.data.shape)
+        unique_1 = np.unique(e_1.data)
+
+        # Rotate
+        angle = np.deg2rad(i)
+        dcm = rotations.roty(angle)
+        e_2 = e_1.rotate(dcm, order=0)
+
+        unique_2 = np.unique(e_2.data) 
+        assert len(unique_2) > 0, f"Format {format_1}: unique_2 is empty"
+        for x in unique_2:
+            assert x in unique_1, f"Format {format_1}: {x} was not in {unique_1}"
+
+
+@pytest.mark.parametrize("format_1",  (SUPPORTED_FORMATS))
+def test_interpolation_resize_discrete_values(format_1):
+    # scale() should not change the unique values in the data while upscaling
+    for s in [32,64,100,200,256,512]:
+        e_1 = EnvironmentMap(128, format_1)
+        e_1.data = np.random.randint(0,128, size=e_1.data.shape)
+        unique_1 = [ x for x in np.unique(e_1.data) if not np.isnan(x) ]
+
+        e_2 = e_1.resize(s, order=0)
+        unique_2 = [ x for x in np.unique(e_2.data) if not np.isnan(x) ]
+
+        assert len(unique_2) > 0, f"Format {format_1}: unique_2 is empty"
+        for x in unique_2:
+            assert x in unique_1 , f"Format {format_1}: {x} was not in {unique_1}"


### PR DESCRIPTION
Enable handling of discrete images (e.g. class labels) without introducing new values with interpolation.
This is done by making the spline interpolation `order` parameter available to all functions that use `interpolate()`  (`resize()`, `rotate()`, and `convertTo()` ).  

Note:
 `order=0` is Nearest Neighbor Interpolation 
 `order=1` [*DEFAULT*] is Linear Interpolation 

A test suite has been added to confirm functionality