### PR TITLE
Test case for image2world() and world2image() transforms

### DIFF
--- a/test/test_projections.py
+++ b/test/test_projections.py
@@ -100,3 +100,25 @@ def test_projections_pixel():
 
         np.testing.assert_array_equal(U_, U)
         np.testing.assert_array_equal(V_, V)
+
+
+@pytest.mark.parametrize("format_", env.SUPPORTED_FORMATS)
+def test_projections_image(format_):
+    
+    e = env.EnvironmentMap(8, format_, channels=2)
+
+    # Meshgrid of Normalized Coordinates 
+    cols = np.linspace(0, 1, e.data.shape[1]*2 + 1)
+    rows = np.linspace(0, 1, e.data.shape[0]*2 + 1)
+    cols = cols[1::2]
+    rows = rows[1::2]
+    U, V = np.meshgrid(cols, rows)
+
+    # image2world(U,V)
+    x, y, z, valid = e.image2world(U,V) 
+
+    # world2image(x,y,z)
+    U_, V_ = e.world2image(x,y,z)
+
+    np.testing.assert_array_almost_equal(U[valid], U_[valid], decimal=6)
+    np.testing.assert_array_almost_equal(V[valid], V_[valid], decimal=6)

--- a/test/test_projections.py
+++ b/test/test_projections.py
@@ -27,7 +27,6 @@ def test_projections_cube(coordinate_UV, coordinate_XYZR):
     X, Y, Z, R = coordinate_XYZR
     U, V = coordinate_UV
 
-
     # --- Singular float coordinates --- #
     if R == True:
         u, v = t.world2cube(X, Y, Z)
@@ -67,58 +66,49 @@ def test_projections_cube(coordinate_UV, coordinate_XYZR):
     np.testing.assert_almost_equal(y_, Y_, decimal=6)
     np.testing.assert_almost_equal(z_, Z_, decimal=6)
 
-def test_projections_pixel():
-    
-    env_formats = [ 'angular', 'skyangular', 'latlong', 'skylatlong', 'sphere', 'cube' ]
 
-    for format in env_formats:
-        e = env.EnvironmentMap(8, format, channels=2)
+@pytest.mark.parametrize("format_", env.SUPPORTED_FORMATS)
+def test_projections_pixel(format_):
+    e = env.EnvironmentMap(64, format_, channels=2)
 
-        # Meshgrid of Normalized Coordinates 
-        cols = np.linspace(0, 1, e.data.shape[1]*2 + 1)
-        rows = np.linspace(0, 1, e.data.shape[0]*2 + 1)
-        cols = cols[1::2]
-        rows = rows[1::2]
-        u, v = np.meshgrid(cols, rows)
+    # Meshgrid of Normalized Coordinates 
+    u, v = e.imageCoordinates()
 
-        # Meshgrid of M*N image Coordinates 
-        cols = np.linspace(0, e.data.shape[1]-1, e.data.shape[1])
-        rows = np.linspace(0, e.data.shape[0]-1, e.data.shape[0])
-        U, V = np.meshgrid(cols, rows)
+    # Meshgrid of M*N image Coordinates 
+    cols = np.linspace(0, e.data.shape[1] - 1, e.data.shape[1])
+    rows = np.linspace(0, e.data.shape[0] - 1, e.data.shape[0])
+    U, V = np.meshgrid(cols, rows)
 
-        # pixel2world(U,V)
-        x, y, z, v = e.image2world(u,v) 
-        x_, y_, z_, v_ = e.pixel2world(U, V)
+    x, y, z, valid = e.image2world(u, v)
+    x_, y_, z_, valid_ = e.pixel2world(U, V)
 
-        np.testing.assert_array_almost_equal(x, x_, decimal=6)
-        np.testing.assert_array_almost_equal(y, y_, decimal=6)
-        np.testing.assert_array_almost_equal(z, z_, decimal=6)
-        np.testing.assert_array_equal(v,v_)
+    np.testing.assert_array_almost_equal(x[valid], x_[valid_], decimal=5)
+    np.testing.assert_array_almost_equal(y[valid], y_[valid_], decimal=5)
+    np.testing.assert_array_almost_equal(z[valid], z_[valid_], decimal=5)
+    np.testing.assert_array_equal(valid, valid_)
 
-        # world2pixel(x,y,z)
-        U_, V_ = e.world2pixel(x,y,z)
+    # world2pixel(x,y,z)
+    U_, V_ = e.world2pixel(x, y, z)
 
-        np.testing.assert_array_equal(U_, U)
-        np.testing.assert_array_equal(V_, V)
+    np.testing.assert_array_equal(U_[valid_], U[valid_])
+    np.testing.assert_array_equal(V_[valid_], V[valid_])
 
 
 @pytest.mark.parametrize("format_", env.SUPPORTED_FORMATS)
 def test_projections_image(format_):
-    
-    e = env.EnvironmentMap(8, format_, channels=2)
+
+    e = env.EnvironmentMap(64, format_, channels=2)
 
     # Meshgrid of Normalized Coordinates 
-    cols = np.linspace(0, 1, e.data.shape[1]*2 + 1)
-    rows = np.linspace(0, 1, e.data.shape[0]*2 + 1)
-    cols = cols[1::2]
-    rows = rows[1::2]
-    U, V = np.meshgrid(cols, rows)
+    cols = np.linspace(0, 1, e.data.shape[1]*2 + 1)[1::2]
+    rows = np.linspace(0, 1, e.data.shape[0]*2 + 1)[1::2]
+    u, v = np.meshgrid(cols, rows)
 
     # image2world(U,V)
-    x, y, z, valid = e.image2world(U,V) 
+    x, y, z, valid = e.image2world(u, v)
 
     # world2image(x,y,z)
-    U_, V_ = e.world2image(x,y,z)
+    u_, v_ = e.world2image(x, y, z)
 
-    np.testing.assert_array_almost_equal(U[valid], U_[valid], decimal=6)
-    np.testing.assert_array_almost_equal(V[valid], V_[valid], decimal=6)
+    np.testing.assert_array_almost_equal(u[valid], u_[valid], decimal=5)
+    np.testing.assert_array_almost_equal(v[valid], v_[valid], decimal=5)


### PR DESCRIPTION
Tests bijection pairs  `image2world()` and `world2image()` 

```python
# image2world(U,V)
x, y, z, valid = e.image2world(U,V) 

# world2image(x,y,z)
U_, V_ = e.world2image(x,y,z)

# assert U == U_ and V == V_ 
```

Same result when lines 110 - 115 are replaced with `imageCoordinates()`