### PR TITLE
Added support for omnidirectional cameras

### DIFF
--- a/envmap/projections.py
+++ b/envmap/projections.py
@@ -1,6 +1,7 @@
 import numpy as np
 from numpy import logical_and as land, logical_or as lor
 
+from .rotations import *
 
 def world2latlong(x, y, z):
     """Get the (u, v) coordinates of the point defined by (x, y, z) for
@@ -295,3 +296,114 @@ def cube2world(u, v):
         return x.item(), y.item(), z.item(), valid.item()
 
     return x, y, z, valid
+
+
+def ocam2world(u, v, ocam_calibration):
+    """ Project a point (u, v) in omnidirectional camera space to 
+    (x, y, z) point in world coordinate space."""
+
+    # Step 0. De-Normalize coordinates to interval defined by the MxN image
+    # Where u=cols(x),  v=rows(y)
+    width_cols = ocam_calibration['width']
+    height_rows = ocam_calibration['height']
+
+    v = np.floor(v*width_cols).astype(int)
+    u = np.floor(u*height_rows).astype(int)
+
+    # Step 1. Center & Skew correction
+    # M = affine matrix [c,d,xc; e,1,yc; 0,0,1]
+    # p' = M^-1 * (p)
+    M = ocam_calibration['affine_3x3']
+    F = ocam_calibration['F']
+
+    # Inverse: M_ = M^-1
+    M_ = np.linalg.inv(M)
+
+    # Affine transform
+    w = np.ones_like(u)
+    assert u.shape == v.shape
+    save_original_shape = u.shape
+    p_uvw = np.array((u.reshape(-1),v.reshape(-1),w.reshape(-1)))
+    p_xyz = np.matmul(M_,p_uvw)
+
+    # Add epsilon to mitigate NAN
+    p_xyz[ p_xyz==0 ] = np.finfo(p_xyz.dtype).eps
+
+    # Step 2. Get unit-sphere world coordinate z
+    # Distance to center of image: p = sqrt(X^2 + Y^2)
+    p_z = np.linalg.norm(p_xyz[0:2], axis=0)
+    # Convert to z-coordinate with p_z = F(p)
+    p_xyz[2] = F(p_z)
+
+    # Step 3. Normalize x,y,z to unit length of 1 (unit sphere)
+    p_xyz = p_xyz / np.linalg.norm(p_xyz, axis=0)
+
+    # Step 4. Fix coordinate system alignment 
+    # (rotate -90 degrees around z-axis)
+    # (x,y,z) -> (x,-z,y) as +y is up (not +z)
+    p_xyz = np.matmul(rotz(np.deg2rad(-90)),p_xyz)
+    x,y,z = (
+        p_xyz[0].reshape(save_original_shape),
+        -p_xyz[2].reshape(save_original_shape),
+        -p_xyz[1].reshape(save_original_shape)
+    )
+
+    valid = np.ones(x.shape, dtype='bool')
+    return x,y,z, valid
+
+
+def world2ocam(x, y, z, ocam_calibration):
+    """ Project a point (x, y, z) in world coordinate space to 
+    a (u, v) point in omnidirectional camera space."""
+
+    # Step 1. Center & Skew correction
+    # M = affine matrix [c,d; e,1]
+    # T = translation vector
+    # p' = M^-1 * (p - T)
+    M = ocam_calibration['affine_3x3']
+    F = ocam_calibration['F']
+
+    assert x.shape == y.shape and x.shape == z.shape, f'{x.shape} == {y.shape} == {z.shape}'
+    save_original_shape = x.shape
+
+    # Step 2. Fix coordinate system alignment
+    # (x,y,z) -> (x,z,-y) as +z is up (not +y)
+    p_xyz = np.array((x.reshape(-1),y.reshape(-1),-z.reshape(-1)))
+                      
+    # Add epsilon to mitigate NAN
+    p_xyz[ p_xyz==0 ] = np.finfo(p_xyz.dtype).eps
+                      
+    # (rotate 90 degrees around z-axis)
+    p_xyz = np.array((p_xyz[0], p_xyz[2], -p_xyz[1]))
+    p_xyz = np.matmul(rotz(np.deg2rad(90)),p_xyz)
+
+    # Step 3. 3D to 2D
+    m = p_xyz[2] / np.linalg.norm(p_xyz[0:2], axis=0)
+
+    def poly_inverse(y):
+        F_ = F.copy()
+        F_.coef[1] -=y
+        F_r = F_.roots()
+        F_r = F_r[ (F_r >= 0) & (F_r.imag == 0) ]
+        if len(F_r)>0:
+            return F_r[0].real
+        else:
+            return np.nan
+    m_ = np.vectorize(poly_inverse)(m)
+
+    uvw = p_xyz / np.linalg.norm(p_xyz[0:2], axis=0) * m_
+
+    # Step 4. Affine transform for center and skew
+    uvw[2,:] = 1
+    uvw = np.nan_to_num(uvw)
+    uvw = np.matmul(M, uvw)
+    u,v = uvw[0].reshape(save_original_shape), uvw[1].reshape(save_original_shape)
+
+    # Step 3. Normalize coordinates to interval [0,1]
+    # Where u=cols(x),  v=rows(y)
+    width_cols = ocam_calibration['width']
+    height_rows = ocam_calibration['height']
+    u = (u+0.5) / height_rows
+    v = (v+0.5) / width_cols
+
+    return u,v

--- a/envmap/xmlhelper.py
+++ b/envmap/xmlhelper.py
@@ -1,3 +1,5 @@
+import numpy as np
+import datetime as dt
 import xml.etree.ElementTree as ET
 
 
@@ -9,26 +11,101 @@ class EnvmapXMLParser:
         self.tree = ET.parse(filename)
         self.root = self.tree.getroot()
 
+
     def _getFirstChildTag(self, tag):
         for elem in self.root:
             if elem.tag == tag:
                 return elem.attrib
+
 
     def _getAttrib(self, node, attribute, default=None):
         if node:
             return node.get(attribute, default)
         return default
 
+
     def getFormat(self):
         """Returns the format of the environment map."""
         node = self._getFirstChildTag('data')
         return self._getAttrib(node, 'format', 'Unknown')
 
+
     def getDate(self):
-        """Returns the date of the environment mapin dict format."""
+        """Returns the date of the environment map in dict format."""
         return self._getFirstChildTag('date')
+
+
+    def get_datetime(self):
+        """Returns the date of the environment map in datetime format."""
+        # Example: <date day="24" hour="16" minute="36" month="9" second="49.1429" utc="-4" year="2014"/>
+        date = self.root.find('date')
+        year = date.get('year')
+        month = date.get('month').zfill(2)
+        day = date.get('day').zfill(2)
+        hour = date.get('hour').zfill(2)
+        minute = date.get('minute').zfill(2)
+        second = str(int(float(date.get('second')))).zfill(2)
+        utc_offset = int(date.get('utc'))
+        if utc_offset > 0:
+            utc_offset = f'+{str(utc_offset).zfill(2)}'
+        else:
+            utc_offset = f'-{str(np.abs(utc_offset)).zfill(2)}'
+        return dt.datetime.fromisoformat(f"{year}-{month}-{day} {hour}:{minute}:{second}{utc_offset}:00")
+
+
+    def get_calibration(self):
+        """Returns the OCamCalib calibration metadata."""
+
+        calibration = {}
+        # Calibration Model
+        node = self.root.find('calibrationModel')
+        # Affine 2D = [c,d;
+        #              e,1];
+        c = float(node.get('c'))
+        d = float(node.get('d'))
+        e = float(node.get('e'))
+        affine_2x2 = np.array([[c,d],[e, 1]])
+        calibration['c'] = c
+        calibration['d'] = d
+        calibration['e'] = e
+        calibration['affine_2x2'] = affine_2x2
+
+        # shape = [height, width]
+        height = int(node.get('height'))
+        width = int(node.get('width'))
+        calibration['height'] = height
+        calibration['width'] = width
+        calibration['shape'] = (height, width)
+
+        # center = [xc, yc]
+        xc = float(node.get('xc'))
+        yc = float(node.get('yc'))
+        calibration['xc'] = xc
+        calibration['yc'] = yc
+        calibration['center'] = (xc, yc)
+
+        # Affine 3D = [c,d,xc;
+        #              e,1,yc;
+        #              0,0,1];
+        affine_3x3 = np.array([[c,d,xc],[e, 1, yc],[0,0,1]])
+        calibration['affine_3x3'] = affine_3x3
+
+        # ss = [a_0, a_1, ..., a_n]
+        ss = [ float(s.get('s')) for s in node.findall('ss') ]
+        calibration['ss'] = np.array(ss)
+        polydomain = xc if xc > yc else yc
+        polydomain = [-polydomain,polydomain]
+        calibration['F'] = \
+            np.polynomial.polynomial.Polynomial(
+                ss,
+                domain=polydomain,
+                window=polydomain
+            )
+
+        return calibration
+
 
     def getExposure(self):
         """Returns the exposure of the environment map in EV."""
         node = self._getFirstChildTag('exposure')
-        return self._getAttrib(node, 'EV')
+        return float(self._getAttrib(node, 'EV'))

--- a/test/test_projections.py
+++ b/test/test_projections.py
@@ -1,5 +1,4 @@
 import pytest
-import math
 import numpy as np
 
 from envmap import projections as t
@@ -113,3 +112,31 @@ def test_projections_image(format_):
 
     np.testing.assert_array_almost_equal(u[valid], u_[valid], decimal=5)
     np.testing.assert_array_almost_equal(v[valid], v_[valid], decimal=5)
+
+
+@pytest.mark.parametrize("calibration",
+    [
+        # ( ocam calibration dict, from 20150909_144054_stack.meta.xml )
+        ({
+            'height': 3840,
+            'width': 5760,
+            'F' : np.polynomial.polynomial.Polynomial(
+                np.array([-1283.8735,0,0.00035359,-1.2974e-07,6.7764e-11]),
+                domain=[-2895.3481,2895.3481],
+                window=[-2895.3481,2895.3481]
+            ),
+            'affine_3x3':np.array([[0.99981,0.00024371,1904.2826],[3.7633e-06, 1, 2895.3481],[0,0,1]]),
+        }),
+    ]
+)
+def test_ocam(calibration):
+
+    e = env.EnvironmentMap(64, 'skyangular', channels=2)
+    x,y,z, valid = e.worldCoordinates()
+
+    u_, v_ = t.world2ocam(x, y, z, calibration)
+    x_, y_, z_, V = t.ocam2world(u_, v_, calibration)
+
+    np.testing.assert_array_almost_equal(x[valid], x_[valid], decimal=3)
+    np.testing.assert_array_almost_equal(y[valid], y_[valid], decimal=3)
+    np.testing.assert_array_almost_equal(z[valid], z_[valid], decimal=3)


### PR DESCRIPTION
Adds support for generating environment maps from images captured with a calibrated omnidirectional camera per the [OCamCalib: Omnidirectional Camera Calibration Toolbox for Matlab](https://sites.google.com/site/scarabotix/ocamcalib-omnidirectional-camera-calibration-toolbox-for-matlab?authuser=0)

Example Calibration: _20150909_144054_stack.meta.xml_
```xml
<?xml version="1.0" encoding="utf-8"?>
<document version="1">
   <data file="/dev/shm/dataCreateHDR-1440544d7f310d09054dadae12f1fa0bca017b/stack.exr" format="Omnidirectional"/>
   <calibrationModel c="0.99981" d="0.00024371" e="3.7633e-06" height="3840" width="5760" xc="1904.2826" yc="2895.3481">
      <ss s="-1283.8735"/>
      <ss s="0"/>
      <ss s="0.00035359"/>
      <ss s="-1.2974e-07"/>
      <ss s="6.7764e-11"/>
   </calibrationModel>
   <date day="9" hour="14" minute="40" month="9" second="55.7143" utc="-4" year="2015"/>
   <exposure EV="15"/>
</document>
```

The above calibration is loaded to a dictionary via added functionality in [envmap/xmlhelper.py](https://github.com/soravux/skylibs/compare/master...IanMaquignaz:omnidirectional_camera?expand=1#diff-6af50bfd11ec3b2659ea78a4e04da17454696fd54716566c55f0e2455e1161b6)

To support the new function [envmap.EnvironmentMap.from_omnicam(...)](https://github.com/soravux/skylibs/compare/master...IanMaquignaz:omnidirectional_camera?expand=1#diff-fdae96e93b842328bfd29b9190c6b21aa9f4006791f5b9c0cdc83c4ccec8e833) two new transformations  `world2ocam(...)` and `ocam2world(...)` have been added to [envmap/projections.py](https://github.com/soravux/skylibs/compare/master...IanMaquignaz:omnidirectional_camera?expand=1#diff-a5741f2ba3e3e8073d2b2974809f545a37afac893e9a3c11cb0035a3cc8b533a). To ensure conformity between the coordinate systems, a test cases has been added to [test/test_projections.py](https://github.com/soravux/skylibs/compare/master...IanMaquignaz:omnidirectional_camera?expand=1#diff-a5741f2ba3e3e8073d2b2974809f545a37afac893e9a3c11cb0035a3cc8b533a). 

**Example**
> _input image_:
<img src="https://github.com/soravux/skylibs/assets/7108263/64087da3-4794-4cb5-8354-794edab0154a" height="250">

>_get latlong environment map:_
```python
e = envmap.EnvironmentMap.from_omnicam(im_path, targetDim=256, targetFormat='latlong')
```
<img src="https://github.com/soravux/skylibs/assets/7108263/ada3f66b-a561-4de8-8cb7-d37afa1918fc" height="250">

**World XYZ coordinates to omnidirectional camera image:**
<img src="https://github.com/soravux/skylibs/assets/7108263/5f11f8c3-ba5f-4735-b835-0ebc3e160929" height="250">



**Know issues:**
- Computationally expensive. If needed for batch operations, strongly suggest looking into [Opencv Remap](https://docs.opencv.org/4.7.0/d1/da0/tutorial_remap.html). 