### PR TITLE
Fixes setBackgroundColor(...)

### DIFF
--- a/test/test_envmap.py
+++ b/test/test_envmap.py
@@ -268,3 +268,23 @@ def test_interpolation_resize_discrete_values(format_):
         assert len(unique_2) > 0, f"Format {format_}: unique_2 is empty"
         for x in unique_2:
             assert x in unique_1 , f"Format {format_}: {x} was not in {unique_1}"
+            
+
+@pytest.mark.parametrize("format_,channels_", product(SUPPORTED_FORMATS, [1,3,4,5,7]))
+def test_setBackgroundColor(format_, channels_):
+    # Checks that the background color is correctly set
+    
+    # RGB
+    for s in [32,64,100,200,256,512]:
+        e_1 = EnvironmentMap(s, format_, channels=channels_)
+        initial_color = np.random.randint(0, 128)
+        e_1.data[:] = initial_color
+        sum_e_1 = e_1.data.sum()
+        
+        new_color=np.random.randint(129, 254)
+        _, _, _, valid = e_1.worldCoordinates()
+        sum_valid = np.invert(valid).sum() * e_1.data.shape[2] * (new_color - initial_color)
+        e_1 = e_1.setBackgroundColor(color=new_color, valid=valid)
+        
+        assert e_1.data.shape[2] == channels_
+        assert e_1.data.sum() == sum_e_1 + sum_valid   


### PR DESCRIPTION
Fixes bug where `setBackgroundColor(...)` crashes in the event of a channel mismatch. 

Change list:
- Makes default color [0], instead of [0,0,0]. 
- Calling `setBackgroundColor(..., color,...)` no longer overwrites `self.backgroundColor = color`
- Color [0] is repeated for any number of color channels (e.g. RGB = [0,0,0])
- New implementation removes weird logic and is now 2.13x faster!
- Test case `test_setBackgroundColor(...)` has been added

**_Note!_** Using `setBackgroundColor(..., valid=None)` results in the re-computation of `valid` using `worldCoordinates()`. This is _**VERY**_ expensive and should be avoided.

```python
N=1000
start = time.time()
for _ in range(N):
     # Original Implementation
     if mask.sum() > 0:
         e.data[np.tile(mask[:,:,None], (1, 1, e.data.shape[2]))] = np.tile(e.backgroundColor, (mask.sum(),))
end = time.time()
dt = (end-start) / N
print(dt)

start = time.time()
for _ in range(N):
     # New Implementation
     self.data[np.invert(valid)] = backgroundColor
end = time.time()
dt = (end-start) / N
print(dt)
```

Output
```Bash
0.010673324823379517
0.005012984275817871
```
