### PR TITLE
Pyshtools fix + speed up reading multichannel EXR files

### DIFF
--- a/tools3d/spharm.py
+++ b/tools3d/spharm.py
@@ -37,7 +37,7 @@ class SphericalHarmonic:
 
         self.coeffs = []
         for i in range(self.spatial.data.shape[2]):
-            self.coeffs.append(_SHTOOLS.SHExpandDH(self.spatial.data[:,:,i], norm=norm, sampling=2, lmax_calc=max_l))
+            self.coeffs.append(_SHTOOLS.SHExpandDH(self.spatial.data[:,:,i], norm=norm, sampling=2, lmax_calc=max_l)[1])
 
     def reconstruct(self, height=None, max_l=None, clamp_negative=True):
         """
@@ -47,7 +47,7 @@ class SphericalHarmonic:
 
         retval = []
         for i in range(len(self.coeffs)):
-            retval.append(_SHTOOLS.MakeGridDH(self.coeffs[i][1], norm=self.norm, sampling=2, lmax=height, lmax_calc=max_l)[1])
+            retval.append(_SHTOOLS.MakeGridDH(self.coeffs[i], norm=self.norm, sampling=2, lmax=height, lmax_calc=max_l)[1])
 
         retval = np.asarray(retval).transpose((1,2,0))
 

--- a/tools3d/spharm.py
+++ b/tools3d/spharm.py
@@ -2,7 +2,7 @@ import os
 
 import numpy as np
 from scipy.special import sph_harm
-from pyshtools import _SHTOOLS
+from pyshtools.backends import shtools
 
 from envmap import EnvironmentMap
 
@@ -37,7 +37,7 @@ class SphericalHarmonic:
 
         self.coeffs = []
         for i in range(self.spatial.data.shape[2]):
-            self.coeffs.append(_SHTOOLS.SHExpandDH(self.spatial.data[:,:,i], norm=norm, sampling=2, lmax_calc=max_l)[1])
+            self.coeffs.append(shtools.SHExpandDH(self.spatial.data[:,:,i], norm=norm, sampling=2, lmax_calc=max_l))
 
     def reconstruct(self, height=None, max_l=None, clamp_negative=True):
         """
@@ -47,7 +47,7 @@ class SphericalHarmonic:
 
         retval = []
         for i in range(len(self.coeffs)):
-            retval.append(_SHTOOLS.MakeGridDH(self.coeffs[i], norm=self.norm, sampling=2, lmax=height, lmax_calc=max_l)[1])
+            retval.append(shtools.MakeGridDH(self.coeffs[i], norm=self.norm, sampling=2, lmax=height, lmax_calc=max_l))
 
         retval = np.asarray(retval).transpose((1,2,0))
 

--- a/tools3d/spharm.py
+++ b/tools3d/spharm.py
@@ -2,7 +2,7 @@ import os
 
 import numpy as np
 from scipy.special import sph_harm
-from pyshtools import shtools
+from pyshtools import _SHTOOLS
 
 from envmap import EnvironmentMap
 
@@ -37,7 +37,7 @@ class SphericalHarmonic:
 
         self.coeffs = []
         for i in range(self.spatial.data.shape[2]):
-            self.coeffs.append(shtools.SHExpandDH(self.spatial.data[:,:,i], norm=norm, sampling=2, lmax_calc=max_l))
+            self.coeffs.append(_SHTOOLS.SHExpandDH(self.spatial.data[:,:,i], norm=norm, sampling=2, lmax_calc=max_l))
 
     def reconstruct(self, height=None, max_l=None, clamp_negative=True):
         """
@@ -47,7 +47,7 @@ class SphericalHarmonic:
 
         retval = []
         for i in range(len(self.coeffs)):
-            retval.append(shtools.MakeGridDH(self.coeffs[i], norm=self.norm, sampling=2, lmax=height, lmax_calc=max_l))
+            retval.append(_SHTOOLS.MakeGridDH(self.coeffs[i][1], norm=self.norm, sampling=2, lmax=height, lmax_calc=max_l)[1])
 
         retval = np.asarray(retval).transpose((1,2,0))
 


### PR DESCRIPTION
This PR contains two different fixes:

1. Pyshtools fix
  I don't know if the API of pyshtools changed, but now `pyshtools.shtools` needs to be instead `pyshtools.backend.shtools` (there's an ImportError otherwise).

2. Speed up reading multichannel EXR files
  I run into this issue often: I save multichannel EXR files using Blender, compressed in DWAA (to save space), and the time to read them using skylibs' OpenEXR image reader is very slow (in the order of seconds). I found out that we can improve the read time by only reading the specific EXR channels we are interested in, which saves a lot of CPU compute cycles, since OpenEXR only needs to decompress these specific channels. So I added code to read only specific channels (by matching regex expressions), so you can do something like:
    ````
    ezexr.imread('big-multichannel-exr-image.exr', rgb="hybrid", whitelisted_channels=['mask', r'background\.[RGB]', r'composite\.[RGB]'])
    ````
    to just read the `mask`, and the RGB values (not alpha) of `background` and `composite`, but avoids loading any other channels.
    I think that this is useful even if using other compression schemes (or no compression at all).